### PR TITLE
chore(pre-align): align heading structure (3 docs) with ko

### DIFF
--- a/en/console-guide.md
+++ b/en/console-guide.md
@@ -1,10 +1,15 @@
-## Network > NAT Gateway > Console User Guide
+<!-- pre-align:aligned sig=817b7fe12b3a -->
+
+<a id="network-nat-gateway-console-user-guide"></a>
+## Network > NAT Gateway > Console User Guide { #network-nat-gateway-console-user-guide }
 This guide describes how to use the NAT Gateway service from the console.
 
-## NAT Gateway 
+<a id="nat-gateway"></a>
+## NAT Gateway { #nat-gateway }
 This function is only available in the Korea (Pangyo) and Korea (Pyeongchon) regions.
 
-### Create an NAT Gateway
+<a id="create-an-nat-gateway"></a>
+### Create an NAT Gateway { #create-an-nat-gateway }
 Create an NAT gateway by setting the items below.
 
 | Item      | Description                                                         |
@@ -22,7 +27,8 @@ Create an NAT gateway by setting the items below.
 * Network ACLs are applied to the Korea (Pyeongchon) region.
 * The quota for NAT gateway is 3.
 
-### Configure a Route
+<a id="configure-a-route"></a>
+### Configure a Route { #configure-a-route }
 * If you configure a route in the routing table that specifies the NAT gateway as a gateway for a specific CIDR, the NAT gateway is used.
 * In instances connected to the routing table that has set the NAT gateway as a route, if the CIDR configured in the route is the destination, the source IP of the packet is converted to the floating IP of the NAT gateway.
 * A single NAT gateway can be specified as a gateway in multiple routing tables of the same VPC.
@@ -31,5 +37,6 @@ Create an NAT gateway by setting the items below.
 * If you set the NAT gateway as a gateway for a route destination CIDR other than IP Prefix 0 (/0) in the route configuration, the communication will be performed through the NAT gateway even if the instance has a floating IP configured.
 
 
-### Configure a Network ACL
+<a id="configure-a-network-acl"></a>
+### Configure a Network ACL { #configure-a-network-acl }
 If you configure a network ACL for the VPC of the NAT gateway in the Korea (Pyeongchon) region, it will also be applied to the NAT gateway. [How to configure a network ACL](https://docs.toast.com/en/Network/Network%20ACL/en/overview/)

--- a/en/overview.md
+++ b/en/overview.md
@@ -1,9 +1,13 @@
-## Network > NAT Gateway > Overview
+<!-- pre-align:aligned sig=cda93b6a10e3 -->
+
+<a id="network-nat-gateway-overview"></a>
+## Network > NAT Gateway > Overview { #network-nat-gateway-overview }
 An NAT gateway allows instances that is not connected to an internet gateway to access the internet. However, you cannot initiate connections to these instances from the internet.
 This function is only available in the Korea (Pangyo) and Korea (Pyeongchon) regions.
 
 
-### Main Features
+<a id="main-features"></a>
+### Main Features { #main-features }
 * Instances that are not connected to an internet gateway can access the internet with the floating IP of an NAT gateway.
 * When you configure a route specifying an NAT gateway as a gateway for a specific CIDR in the routing table, the source IP of packets destined for the configured CIDR from the instances connected to this routing table is converted to the floating IP of the NAT gateway.
 * A single NAT gateway can be specified as a gateway in multiple routing tables in the same VPC.

--- a/en/public-api.md
+++ b/en/public-api.md
@@ -1,4 +1,7 @@
-## Network > NAT Gateway > API v2 Guide
+<!-- pre-align:aligned sig=19e667668707 -->
+
+<a id="network-nat-gateway-api-v2-guide"></a>
+## Network > NAT Gateway > API v2 Guide { #network-nat-gateway-api-v2-guide }
 
 NHN Cloud Network services use IaaS tokens for authentication and authorization when making API calls. The IaaS token is an authentication token used for NHN Cloud's OpenStack-based infrastructure services (IaaS). For more information on issuing and using IaaS tokens, please refer to the [IaaS Token](/nhncloud/en/public-api/iaas-token).
 
@@ -11,13 +14,16 @@ The NAT Gateway API utilizes an endpoint of the `network` type. The exact endpoi
 In each API response, you may find fields that are not specified within this guide. Those fields are for NHN Cloud internal usage, so refrain from using them because they may be changed without prior notice.
 
 
-## NAT gateway
-### View a list of NAT gateways
+<a id="nat-gateway"></a>
+## NAT gateway { #nat-gateway }
+<a id="view-a-list-of-nat-gateways"></a>
+### View a list of NAT gateways { #view-a-list-of-nat-gateways }
 ```
 GET /v2.0/natgateways
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-a-list-of-nat-gateways-request"></a>
 #### Request
 This API does not require a request body.
 
@@ -31,6 +37,7 @@ This API does not require a request body.
 | sort_key | Query | String | - | Sort key of the NAT gateway to retrieve<br>Sort in the direction as specified by `sort_dir`                                |
 | fields | Query | String | - | Field name of the NAT gateway to retrieve<br>Example: `fields=id&fields=name`                             |
 
+<a id="view-a-list-of-nat-gateways-response"></a>
 #### Response
 
 | Name                         | Type | Format | Description                                             |
@@ -81,12 +88,14 @@ This API does not require a request body.
 
 ---
 
-### View NAT Gateways
+<a id="view-nat-gateways"></a>
+### View NAT Gateways { #view-nat-gateways }
 ```
 GET /v2.0/natgateways/{NatGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-nat-gateways-request"></a>
 #### Request
 This API does not require a request body.
 
@@ -96,6 +105,7 @@ This API does not require a request body.
 | tokenId | Header | String | O | Token ID                                                                |
 | fields | Query  | String | - | Field name of the NAT gateway to retrieve<br>Return only specified fields in the response<br>Example: `fields=id&fields=name` |
 
+<a id="view-nat-gateways-response"></a>
 #### Response
 
 | Name                        | Type | Format | Description                                               |
@@ -143,7 +153,8 @@ This API does not require a request body.
 </details>
 
 ---
-### Create a NAT gateway
+<a id="create-a-nat-gateway"></a>
+### Create a NAT gateway { #create-a-nat-gateway }
 
 Create a new NAT gateway.
 
@@ -152,6 +163,7 @@ POST /v2.0/natgateways
 X-Auth-Token: {tokenId}
 ```
 
+<a id="create-a-nat-gateway-request"></a>
 #### Request
 
 | Name                        | Type | Format     | Required | Description                   |
@@ -185,6 +197,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="create-a-nat-gateway-response"></a>
 #### Response
 | Name                        | Type | Format | Description                                               |
 |---------------------------|---|---|--------------------------------------------------|
@@ -231,7 +244,8 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### Modifying the NAT gateway
+<a id="modifying-the-nat-gateway"></a>
+### Modifying the NAT gateway { #modifying-the-nat-gateway }
 
 Modify an existing NAT gateway.
 
@@ -240,6 +254,7 @@ PUT /v2.0/natgateways/{NatGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="modifying-the-nat-gateway-request"></a>
 #### Request
 
 | Name                        | Type | Format     | Required | Description                 |
@@ -268,6 +283,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="modifying-the-nat-gateway-response"></a>
 #### Response
 | Name                        | Type | Format | Description                                              |
 |---------------------------|---|---|-------------------------------------------------|
@@ -314,13 +330,15 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### Delete a NAT gateway
+<a id="delete-a-nat-gateway"></a>
+### Delete a NAT gateway { #delete-a-nat-gateway }
 Delete the specified NAT gateway.
 ```
 DELETE /v2.0/natgateways/{NatGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="delete-a-nat-gateway-request"></a>
 #### Request
 This API does not require a request body.
 
@@ -329,6 +347,7 @@ This API does not require a request body.
 | NatGatewayId | URL    | UUID   | O  | NAT Gateway ID       |
 | tokenId | Header | String | O | Token ID |
 
+<a id="delete-a-nat-gateway-response"></a>
 #### Response
 This API does not return a response body.
 

--- a/ja/console-guide.md
+++ b/ja/console-guide.md
@@ -1,10 +1,15 @@
-## Network > NAT Gateway > コンソール使用ガイド
+<!-- pre-align:aligned sig=817b7fe12b3a -->
+
+<a id="network-nat-gateway-console-user-guide"></a>
+## Network > NAT Gateway > コンソール使用ガイド { #network-nat-gateway-console-user-guide }
 コンソールでNAT Gatewayサービスを使用する方法を説明します。
 
-## NATゲートウェイ
+<a id="nat-gateway"></a>
+## NATゲートウェイ { #nat-gateway }
 韓国(パンギョ)、韓国(ピョンチョン)リージョンにのみ提供する機能です。
 
-### NATゲートウェイの作成
+<a id="create-an-nat-gateway"></a>
+### NATゲートウェイの作成 { #create-an-nat-gateway }
 以下の項目を設定してNATゲートウェイを作成します。
 
 | 項目    | 説明                                                       |
@@ -22,7 +27,8 @@
 * 韓国(ピョンチョン)リージョンにはネットワークACLが適用されます。
 * NATゲートウェイのQuotaは3個です。
 
-### ルート設定
+<a id="configure-a-route"></a>
+### ルート設定 { #configure-a-route }
 * ルーティングテーブルで特定CIDRに対してNATゲートウェイをゲートウェイに指定するルートを設定すると、NATゲートウェイを使用します。
 * NATゲートウェイをルートに設定したルーティングテーブルに接続されたインスタンスからルートに設定されたCIDRを宛先にする場合、パケットのソースIPがNATゲートウェイのFloating IPに変換されます。
 * 1つのNATゲートウェイは、同じVPC内の複数のルーティングテーブルでゲートウェイに指定できます。
@@ -31,5 +37,6 @@
 * ルート設定でIP Prefix 0 (/0)ではないルート対象CIDRに対してNATゲートウェイをゲートウェイに設定すると、インスタンスにFloating IPが設定されていてもNATゲートウェイで通信されます。
 
 
-### ネットワークACL設定
+<a id="configure-a-network-acl"></a>
+### ネットワークACL設定 { #configure-a-network-acl }
 韓国(ピョンチョン)リージョンでNATゲートウェイのVPCに対してネットワークACL設定を行う場合にNATゲートウェイにも適用されます。 [ネットワークACL設定方法](https://docs.toast.com/ja/Network/Network%20ACL/ja/overview/)

--- a/ja/overview.md
+++ b/ja/overview.md
@@ -1,9 +1,13 @@
-## Network > NAT Gateway > 概要
+<!-- pre-align:aligned sig=cda93b6a10e3 -->
+
+<a id="network-nat-gateway-overview"></a>
+## Network > NAT Gateway > 概要 { #network-nat-gateway-overview }
 NATゲートウェイを利用すると、インターネットゲートウェイが接続されていないインスタンスがインターネットにアクセスできます。しかし、インターネットからこのインスタンスへの接続を始めることはできません。
 韓国(パンギョ)、韓国(ピョンチョン)リージョンでのみ提供する機能です。
 
 
-### 主な機能
+<a id="main-features"></a>
+### 主な機能 { #main-features }
 * インターネットゲートウェイに接続されていないインスタンスがNATゲートウェイのFloating IPでインターネットにアクセスできます。
 * ルーティングテーブルから特定CIDRに対してNATゲートウェイをゲートウェイに指定するルートを設定する場合、このルーティングテーブルに接続されたインスタンスから設定されたCIDRを宛先とするパケットのソースIPはNATゲートウェイのFloating IPに変換されます。
 * 1つのNATゲートウェイは、同じVPC内の複数のルーティングテーブルでゲートウェイに指定できます。

--- a/ja/public-api.md
+++ b/ja/public-api.md
@@ -1,4 +1,7 @@
-## Network > NAT Gateway > API v2ガイド
+<!-- pre-align:aligned sig=19e667668707 -->
+
+<a id="network-nat-gateway-api-v2-guide"></a>
+## Network > NAT Gateway > API v2ガイド { #network-nat-gateway-api-v2-guide }
 
 NHN Cloud Networkサービスは、API呼び出し時の認証/認可のためにIaaSトークンを使用します。IaaSトークンは、NHN CloudのOpenStackベースのインフラサービス(IaaS)で使用する認証トークンです。IaaSトークンの発行及び使用に関する詳細は、[IaaSトークン](/nhncloud/ja/public-api/iaas-token)を参照してください。
 
@@ -11,13 +14,16 @@ NATゲートウェイAPIは`network`タイプエンドポイントを利用し�
 APIレスポンスにガイドに記載されていないフィールドが表示される場合があります。このようなフィールドは、NHN Cloudの内部用途に使用され、事前告知なしに変更される可能性があるため、使用しないでください。
 
 
-## NATゲートウェイ
-### NATゲートウェイ一覧を表示
+<a id="nat-gateway"></a>
+## NATゲートウェイ { #nat-gateway }
+<a id="view-a-list-of-nat-gateways"></a>
+### NATゲートウェイ一覧を表示 { #view-a-list-of-nat-gateways }
 ```
 GET /v2.0/natgateways
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-a-list-of-nat-gateways-request"></a>
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
 
@@ -31,6 +37,7 @@ X-Auth-Token: {tokenId}
 | sort_key | Query | String | - | 照会するNATゲートウェイのソートキー<br>`sort_dir`で指定した方向でソート                              |
 | fields | Query | String | - | 照会するNATゲートウェイのフィールド名<br>例：`fields=id&fields=name`                             |
 
+<a id="view-a-list-of-nat-gateways-response"></a>
 #### レスポンス
 
 | 名前                       | 種類 | 形式 | 説明                                           |
@@ -81,12 +88,14 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### NATゲートウェイ表示
+<a id="view-nat-gateways"></a>
+### NATゲートウェイ表示 { #view-nat-gateways }
 ```
 GET /v2.0/natgateways/{NatGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-nat-gateways-request"></a>
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
 
@@ -96,6 +105,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | トークンID                                                                |
 | fields | Query  | String | - | 照会するNATゲートウェイのフィールド名<br>指定したフィールドのみレスポンスに返す<br>例：`fields=id&fields=name` |
 
+<a id="view-nat-gateways-response"></a>
 #### レスポンス
 
 | 名前                      | 種類 | 形式 | 説明                                             |
@@ -143,7 +153,8 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### NATゲートウェイの作成
+<a id="create-a-nat-gateway"></a>
+### NATゲートウェイの作成 { #create-a-nat-gateway }
 
 新しいNATゲートウェイを作成します。
 
@@ -152,6 +163,7 @@ POST /v2.0/natgateways
 X-Auth-Token: {tokenId}
 ```
 
+<a id="create-a-nat-gateway-request"></a>
 #### リクエスト
 
 | 名前                      | 種類 | 形式   | 必須 | 説明                 |
@@ -185,6 +197,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="create-a-nat-gateway-response"></a>
 #### レスポンス
 | 名前                      | 種類 | 形式 | 説明                                             |
 |---------------------------|---|---|--------------------------------------------------|
@@ -231,7 +244,8 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### NATゲートウェイの修正
+<a id="modifying-the-nat-gateway"></a>
+### NATゲートウェイの修正 { #modifying-the-nat-gateway }
 
 既存NATゲートウェイを修正します。
 
@@ -240,6 +254,7 @@ PUT /v2.0/natgateways/{NatGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="modifying-the-nat-gateway-request"></a>
 #### リクエスト
 
 | 名前                      | 種類 | 形式   | 必須 | 説明               |
@@ -268,6 +283,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="modifying-the-nat-gateway-response"></a>
 #### レスポンス
 | 名前                      | 種類 | 形式 | 説明                                            |
 |---------------------------|---|---|-------------------------------------------------|
@@ -314,13 +330,15 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### NATゲートウェイの削除
+<a id="delete-a-nat-gateway"></a>
+### NATゲートウェイの削除 { #delete-a-nat-gateway }
 指定したNATゲートウェイを削除します。
 ```
 DELETE /v2.0/natgateways/{NatGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="delete-a-nat-gateway-request"></a>
 #### リクエスト
 このAPIはリクエスト本文を要求しません。
 
@@ -329,5 +347,6 @@ X-Auth-Token: {tokenId}
 | NatGatewayId | URL    | UUID   | O  | NATゲートウェイID       |
 | tokenId | Header | String | O | トークンID |
 
+<a id="delete-a-nat-gateway-response"></a>
 #### レスポンス
 このAPIはレスポンス本文を返しません。

--- a/ko/console-guide.md
+++ b/ko/console-guide.md
@@ -1,10 +1,15 @@
-## Network > NAT Gateway > 콘솔 사용 가이드
+<!-- pre-align:aligned sig=817b7fe12b3a -->
+
+<a id="network-nat-gateway-console-user-guide"></a>
+## Network > NAT Gateway > 콘솔 사용 가이드 { #network-nat-gateway-console-user-guide }
 콘솔에서 NAT Gateway 서비스를 사용하는 방법을 설명합니다.
 
-## NAT 게이트웨이 
+<a id="nat-gateway"></a>
+## NAT 게이트웨이 { #nat-gateway }
 한국(판교), 한국(평촌) 리전에만 제공하는 기능입니다.
 
-### NAT 게이트웨이 생성
+<a id="create-an-nat-gateway"></a>
+### NAT 게이트웨이 생성 { #create-an-nat-gateway }
 아래 항목을 설정하여 NAT 게이트웨이를 생성합니다.
 
 | 항목      | 설명                                                         |
@@ -22,7 +27,8 @@
 * 한국(평촌) 리전에는 네트워크 ACL이 적용됩니다.
 * NAT 게이트웨이의 Quota는 3개입니다.
 
-### 라우트 설정
+<a id="configure-a-route"></a>
+### 라우트 설정 { #configure-a-route }
 * 라우팅 테이블에서 특정 CIDR에 대해 NAT 게이트웨이를 게이트웨이로 지정하는 라우트를 설정하면, NAT 게이트웨이를 사용하게 됩니다.
 * NAT 게이트웨이를 라우트로 설정한 라우팅 테이블에 연결된 인스턴스들에서 라우트에 설정된 CIDR을 목적지로 하는 경우, 패킷의 소스 IP가 NAT 게이트웨이의 플로팅 IP로 변환됩니다.
 * 하나의 NAT 게이트웨이는 동일 VPC 내의 여러 라우팅 테이블에서 게이트웨이로 지정할 수 있습니다.
@@ -31,5 +37,6 @@
 * 라우트 설정에서 IP Prefix 0 (/0)이 아닌 라우트 대상 CIDR에 대해 NAT 게이트웨이를 게이트웨이로 설정하면, 인스턴스에 플로팅 IP가 설정되어 있더라도 NAT 게이트웨이로 통신됩니다.
 
 
-### 네트워크 ACL 설정
+<a id="configure-a-network-acl"></a>
+### 네트워크 ACL 설정 { #configure-a-network-acl }
 한국(평촌) 리전에서 NAT 게이트웨이의 VPC에 대해서 네트워크 ACL 설정을 하는 경우에 NAT 게이트웨이에도 적용됩니다. [네트워크 ACL 설정 방법](https://docs.toast.com/ko/Network/Network%20ACL/ko/overview/)

--- a/ko/overview.md
+++ b/ko/overview.md
@@ -1,9 +1,13 @@
-## Network > NAT Gateway > 개요
+<!-- pre-align:aligned sig=cda93b6a10e3 -->
+
+<a id="network-nat-gateway-overview"></a>
+## Network > NAT Gateway > 개요 { #network-nat-gateway-overview }
 NAT 게이트웨이를 이용하면 인터넷 게이트웨이가 연결되지 않은 인스턴스들이 인터넷에 액세스할 수 있습니다. 하지만 인터넷에서 이 인스턴스들로 연결을 시작할 수는 없습니다.
 한국(판교), 한국(평촌) 리전에서만 제공하는 기능입니다.
 
 
-### 주요 기능
+<a id="main-features"></a>
+### 주요 기능 { #main-features }
 * 인터넷 게이트웨이에 연결되지 않은 인스턴스들이 NAT 게이트웨이의 플로팅 IP로 인터넷에 액세스할 수 있습니다.
 * 라우팅 테이블에서 특정 CIDR에 대해 NAT 게이트웨이를 게이트웨이로 지정하는 라우트를 설정하는 경우, 이 라우팅 테이블에 연결된 인스턴스들로부터 설정된 CIDR을 목적지로 하는 패킷의 소스 IP는 NAT 게이트웨이의 플로팅 IP로 변환됩니다.
 * 하나의 NAT 게이트웨이는 동일 VPC 내의 여러 라우팅 테이블에서 게이트웨이로 지정할 수 있습니다.

--- a/ko/public-api.md
+++ b/ko/public-api.md
@@ -1,4 +1,7 @@
-## Network > NAT Gateway > API v2 가이드
+<!-- pre-align:aligned sig=19e667668707 -->
+
+<a id="network-nat-gateway-api-v2-guide"></a>
+## Network > NAT Gateway > API v2 가이드 { #network-nat-gateway-api-v2-guide }
 
 NHN Cloud Network 서비스는 API 호출 시 인증/인가를 위해 IaaS 토큰을 사용합니다. IaaS 토큰은 NHN Cloud의 OpenStack 기반 인프라 서비스(IaaS)에서 사용하는 인증 토큰입니다. IaaS 토큰 발급 및 사용에 대한 자세한 내용은 [IaaS 토큰](/nhncloud/ko/public-api/iaas-token)을 참고하세요.
 
@@ -11,13 +14,16 @@ NAT 게이트웨이 API는 `network` 타입 엔드포인트를 이용합니다. 
 API 응답에 가이드에 명시되지 않은 필드가 나타날 수 있습니다. 이런 필드는 NHN Cloud 내부 용도로 사용되며 사전 공지 없이 변경될 수 있으므로 사용하지 않습니다.
 
 
-## NAT 게이트웨이
-### NAT 게이트웨이 목록 보기
+<a id="nat-gateway"></a>
+## NAT 게이트웨이 { #nat-gateway }
+<a id="view-a-list-of-nat-gateways"></a>
+### NAT 게이트웨이 목록 보기 { #view-a-list-of-nat-gateways }
 ```
 GET /v2.0/natgateways
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-a-list-of-nat-gateways-request"></a>
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
 
@@ -31,6 +37,7 @@ X-Auth-Token: {tokenId}
 | sort_key | Query | String | - | 조회할 NAT 게이트웨이의 정렬 키<br>`sort_dir`에서 지정한 방향대로 정렬                                |
 | fields | Query | String | - | 조회할 NAT 게이트웨이의 필드 이름<br>예: `fields=id&fields=name`                             |
 
+<a id="view-a-list-of-nat-gateways-response"></a>
 #### 응답
 
 | 이름                         | 종류 | 형식 | 설명                                             |
@@ -81,12 +88,14 @@ X-Auth-Token: {tokenId}
 
 ---
 
-### NAT 게이트웨이 보기
+<a id="view-nat-gateways"></a>
+### NAT 게이트웨이 보기 { #view-nat-gateways }
 ```
 GET /v2.0/natgateways/{NatGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="view-nat-gateways-request"></a>
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
 
@@ -96,6 +105,7 @@ X-Auth-Token: {tokenId}
 | tokenId | Header | String | O | 토큰 ID                                                                |
 | fields | Query  | String | - | 조회할 NAT 게이트웨이의 필드 이름<br>지정한 필드만 응답에 반환<br>예: `fields=id&fields=name` |
 
+<a id="view-nat-gateways-response"></a>
 #### 응답
 
 | 이름                        | 종류 | 형식 | 설명                                               |
@@ -143,7 +153,8 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### NAT 게이트웨이 생성하기
+<a id="create-a-nat-gateway"></a>
+### NAT 게이트웨이 생성하기 { #create-a-nat-gateway }
 
 새로운 NAT 게이트웨이를 생성합니다.
 
@@ -152,6 +163,7 @@ POST /v2.0/natgateways
 X-Auth-Token: {tokenId}
 ```
 
+<a id="create-a-nat-gateway-request"></a>
 #### 요청
 
 | 이름                        | 종류 | 형식     | 필수 | 설명                   |
@@ -185,6 +197,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="create-a-nat-gateway-response"></a>
 #### 응답
 | 이름                        | 종류 | 형식 | 설명                                               |
 |---------------------------|---|---|--------------------------------------------------|
@@ -231,7 +244,8 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### NAT 게이트웨이 수정하기
+<a id="modifying-the-nat-gateway"></a>
+### NAT 게이트웨이 수정하기 { #modifying-the-nat-gateway }
 
 기존 NAT 게이트웨이를 수정합니다.
 
@@ -240,6 +254,7 @@ PUT /v2.0/natgateways/{NatGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="modifying-the-nat-gateway-request"></a>
 #### 요청
 
 | 이름                        | 종류 | 형식     | 필수 | 설명                 |
@@ -268,6 +283,7 @@ X-Auth-Token: {tokenId}
 </details>
 
 
+<a id="modifying-the-nat-gateway-response"></a>
 #### 응답
 | 이름                        | 종류 | 형식 | 설명                                              |
 |---------------------------|---|---|-------------------------------------------------|
@@ -314,13 +330,15 @@ X-Auth-Token: {tokenId}
 </details>
 
 ---
-### NAT 게이트웨이 삭제하기
+<a id="delete-a-nat-gateway"></a>
+### NAT 게이트웨이 삭제하기 { #delete-a-nat-gateway }
 지정한 NAT 게이트웨이를 삭제합니다.
 ```
 DELETE /v2.0/natgateways/{NatGatewayId}
 X-Auth-Token: {tokenId}
 ```
 
+<a id="delete-a-nat-gateway-request"></a>
 #### 요청
 이 API는 요청 본문을 요구하지 않습니다.
 
@@ -329,6 +347,7 @@ X-Auth-Token: {tokenId}
 | NatGatewayId | URL    | UUID   | O  | NAT 게이트웨이 ID       |
 | tokenId | Header | String | O | 토큰 ID |
 
+<a id="delete-a-nat-gateway-response"></a>
 #### 응답
 이 API는 응답 본문을 반환하지 않습니다.
 


### PR DESCRIPTION
LLM-matched alignment of `en`/`ja` heading structure to `ko` — heading levels, missing-section stubs, and anchor ids.

**Body text is never modified.** The model only sees heading outlines; edits apply to heading lines (and `<!-- TODO: translate body -->` stubs for missing sections) only.

## Analysis

| | |
| --- | --- |
| Engine | `api (Anthropic SDK)` |
| Model | `claude-sonnet-4-6` |
| Source → targets | `ko` → `en, ja` |
| Base ref | `alpha` |
| Scope | 3 doc(s) scanned · 9 file(s) changed |
| Self-verify | ✅ all aligned |
| Jenkins build | http://cd.cloud.toastoven.net:8080/job/content_deploy/job/align-heading/job/main/95/ |
| Generated | 2026-07-11T07:13:19 |

## Heading compare (docs viewer)

ko ↔ en/ja heading 구조 비교 — base 브랜치(적용 전)와 이 PR(적용 후)를 각각 확인:

- **Base 브랜치** (`alpha`): [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FNAT-Gateway%2Ftree%2Falpha&source=ko&langs=en%2Cja)
- **이 PR**: [Compare ↗](http://content-agent.cloud.toastoven.net:7700/compare-headings?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FNAT-Gateway%2Fpull%2F9&source=ko&langs=en%2Cja)

## Link check

이 PR 의 링크 상태: [Link Check ↗](http://content-agent.cloud.toastoven.net:7700/link-check?url=https%3A%2F%2Fgithub.com%2FTOAST-DOCS%2FNAT-Gateway%2Fpull%2F9&ref=alpha&langs=en%2Cja)

<!-- LINK_CHECK_SUMMARY -->

## Changes

| File | level fixed | inserted | body xl | id fixed | extra flagged | extra demoted | extra removed | marker | verify |
| --- | --: | --: | --: | --: | --: | --: | --: | :--: | :--: |
| `ko/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/console-guide.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ko/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/overview.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ko/public-api.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `en/public-api.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |
| `ja/public-api.md` | 0 | 0 | 0 | 0 | 0 | 0 | 0 | ✅ | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code) · `pre-align/fix_headings.py` on `TOAST-DOCS/NAT-Gateway`